### PR TITLE
fix msbuild version for dotnet 3.1

### DIFF
--- a/Kudu.Core.Test/PathUtilityFacts.cs
+++ b/Kudu.Core.Test/PathUtilityFacts.cs
@@ -110,5 +110,17 @@ namespace Kudu.Core.Test
                 ScmHostingConfigurations.Config = null;
             }
         }
+
+        [Theory]
+        [InlineData("netcoreapp3.1", true)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("netcoreapp3.2", false)]
+        [InlineData("netcoreapp3.11", true)]
+        public void VsHelperIsDotNet31VersionTests(string target, bool expected)
+        {
+            var actual = VsHelper.IsDotNet31Version(target);
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/Kudu.Core/Deployment/Generator/ExternalCommandBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/ExternalCommandBuilder.cs
@@ -48,6 +48,8 @@ namespace Kudu.Core.Deployment.Generator
 
         protected string RepositoryPath { get; private set; }
 
+        protected string TargetFramework { get; set; }
+
         protected IBuildPropertyProvider PropertyProvider { get; private set; }
 
         internal ExternalCommandFactory ExternalCommandFactory { get; private set; }
@@ -80,7 +82,7 @@ namespace Kudu.Core.Deployment.Generator
 
             // Creates an executable pointing to cmd and the working directory being
             // the repository root
-            var exe = ExternalCommandFactory.BuildExternalCommandExecutable(RepositoryPath, context.OutputPath, customLogger);
+            var exe = ExternalCommandFactory.BuildExternalCommandExecutable(RepositoryPath, context.OutputPath, customLogger, TargetFramework);
 
             exe.EnvironmentVariables[WellKnownEnvironmentVariables.PreviousManifestPath] = context.PreviousManifestFilePath ?? String.Empty;
             exe.EnvironmentVariables[WellKnownEnvironmentVariables.NextManifestPath] = context.NextManifestFilePath;

--- a/Kudu.Core/Deployment/Generator/ExternalCommandFactory.cs
+++ b/Kudu.Core/Deployment/Generator/ExternalCommandFactory.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Ionic.BZip2;
 using Kudu.Contracts.Settings;
 using Kudu.Core.Helpers;
 using Kudu.Core.Infrastructure;
@@ -25,12 +26,12 @@ namespace Kudu.Core.Deployment.Generator
             _repositoryPath = repositoryPath;
         }
 
-        public Executable BuildExternalCommandExecutable(string workingDirectory, string deploymentTargetPath, ILogger logger)
+        public Executable BuildExternalCommandExecutable(string workingDirectory, string deploymentTargetPath, ILogger logger, string targetFramework = null)
         {
             string sourcePath = _repositoryPath;
             string targetPath = deploymentTargetPath;
 
-            var exe = BuildCommandExecutable(StarterScriptPath, workingDirectory, _deploymentSettings.GetCommandIdleTimeout(), logger);
+            var exe = BuildCommandExecutable(StarterScriptPath, workingDirectory, _deploymentSettings.GetCommandIdleTimeout(), logger, targetFramework);
             UpdateToDefaultIfNotSet(exe, WellKnownEnvironmentVariables.SourcePath, sourcePath, logger);
             UpdateToDefaultIfNotSet(exe, WellKnownEnvironmentVariables.TargetPath, targetPath, logger);
             UpdateToDefaultIfNotSet(exe, WellKnownEnvironmentVariables.SelectNodeVersionCommandKey, SelectNodeVersionCommand, logger);
@@ -64,7 +65,7 @@ namespace Kudu.Core.Deployment.Generator
             return exe;
         }
 
-        public Executable BuildCommandExecutable(string commandPath, string workingDirectory, TimeSpan idleTimeout, ILogger logger)
+        public Executable BuildCommandExecutable(string commandPath, string workingDirectory, TimeSpan idleTimeout, ILogger logger, string targetFramework = null)
         {
             // Creates an executable pointing to cmd and the working directory being
             // the repository root
@@ -73,7 +74,7 @@ namespace Kudu.Core.Deployment.Generator
             UpdateToDefaultIfNotSet(exe, WellKnownEnvironmentVariables.WebRootPath, _environment.WebRootPath, logger);
             UpdateToDefaultIfNotSet(exe, WellKnownEnvironmentVariables.MSBuildPath, PathUtilityFactory.Instance.ResolveMSBuildPath(), logger);
             UpdateToDefaultIfNotSet(exe, WellKnownEnvironmentVariables.MSBuild15Dir, PathUtilityFactory.Instance.ResolveMSBuild15Dir(), logger);
-            UpdateToDefaultIfNotSet(exe, WellKnownEnvironmentVariables.MSBuild16Dir, PathUtilityFactory.Instance.ResolveMSBuild16Dir(), logger);
+            UpdateToDefaultIfNotSet(exe, WellKnownEnvironmentVariables.MSBuild16Dir, PathUtilityFactory.Instance.ResolveMSBuild16Dir(targetFramework), logger);
             UpdateToDefaultIfNotSet(exe, WellKnownEnvironmentVariables.MSBuild1670Dir, PathUtilityFactory.Instance.ResolveMSBuild1670Dir(), logger);
             UpdateToDefaultIfNotSet(exe, WellKnownEnvironmentVariables.KuduSyncCommandKey, KuduSyncCommand, logger);
             UpdateToDefaultIfNotSet(exe, WellKnownEnvironmentVariables.NuGetExeCommandKey, NuGetExeCommand, logger);

--- a/Kudu.Core/Deployment/Generator/GeneratorSiteBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/GeneratorSiteBuilder.cs
@@ -65,7 +65,7 @@ namespace Kudu.Core.Deployment.Generator
             {
                 using (context.Tracer.Step("Generating deployment script"))
                 {
-                    var scriptGenerator = ExternalCommandFactory.BuildExternalCommandExecutable(RepositoryPath, context.OutputPath, buildLogger);
+                    var scriptGenerator = ExternalCommandFactory.BuildExternalCommandExecutable(RepositoryPath, context.OutputPath, buildLogger, TargetFramework);
 
                     // Set home path to the user profile so cache directories created by azure-cli are created there
                     scriptGenerator.SetHomePath(System.Environment.GetEnvironmentVariable("APPDATA"));

--- a/Kudu.Core/Deployment/Generator/MicrosoftSiteBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/MicrosoftSiteBuilder.cs
@@ -1,6 +1,7 @@
-﻿using Kudu.Contracts.Settings;
-using System;
+﻿using System;
 using System.Text;
+using Kudu.Contracts.Settings;
+using Kudu.Core.Infrastructure;
 
 namespace Kudu.Core.Deployment.Generator
 {
@@ -20,6 +21,7 @@ namespace Kudu.Core.Deployment.Generator
             ProjectFilePath = CleanPath(projectFilePath);
             SolutionPath = CleanPath(solutionPath);
             CommandArgument = commandArgument;
+            TargetFramework = VsHelper.GetTargetFramework(ProjectFilePath); 
         }
 
         protected override string ScriptGeneratorCommandArguments

--- a/Kudu.Core/Infrastructure/PathUtils/PathUtilityBase.cs
+++ b/Kudu.Core/Infrastructure/PathUtils/PathUtilityBase.cs
@@ -66,7 +66,7 @@ namespace Kudu.Core.Infrastructure
             return null;
         }
 
-        internal virtual string ResolveMSBuild16Dir()
+        internal virtual string ResolveMSBuild16Dir(string targetFramework)
         {
             return null;
         }

--- a/Kudu.Core/Infrastructure/PathUtils/PathWindowsUtility.cs
+++ b/Kudu.Core/Infrastructure/PathUtils/PathWindowsUtility.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Kudu.Core.Settings;
 using Kudu.Core.SiteExtensions;
 using SystemEnvironment = System.Environment;
 
@@ -121,7 +122,7 @@ namespace Kudu.Core.Infrastructure
             return probPaths.FirstOrDefault(path => Directory.Exists(path));
         }
 
-        internal override string ResolveMSBuild16Dir()
+        internal override string ResolveMSBuild16Dir(string targetFramework)
         {
             string programFiles = SystemEnvironment.GetFolderPath(SystemEnvironment.SpecialFolder.ProgramFilesX86);
             List<string> probPaths = new List<string>
@@ -132,6 +133,12 @@ namespace Kudu.Core.Infrastructure
                 Path.Combine(programFiles, "Microsoft Visual Studio", "2019", "BuildTools",   "MSBuild", "Current", "Bin"), // msbuild tools
                 // above is for public kudu, below is for azure
             };
+
+            if (VsHelper.IsDotNet31Version(targetFramework) && ScmHostingConfigurations.UseMSBuild167ForDotnet31)
+            {
+                probPaths.Add(Path.Combine(programFiles, "MSBuilds", "16.7.0", "MSBuild", "Current", "Bin"));
+            }
+
             probPaths.Add(Path.Combine(programFiles, "MSBuild-16.4", "MSBuild", "Current", "Bin"));
 
             return probPaths.FirstOrDefault(path => Directory.Exists(path));

--- a/Kudu.Core/Infrastructure/VsHelper.cs
+++ b/Kudu.Core/Infrastructure/VsHelper.cs
@@ -331,7 +331,12 @@ namespace Kudu.Core.Infrastructure
         public static bool IsNewDotNetCoreMajorVersion(string target)
         {
             // Currently only for .NET 5.0 and 6.0
-            return target.StartsWith("net5.0", StringComparison.OrdinalIgnoreCase) || target.StartsWith("net6.0");
+            return target.StartsWith("net5.0", StringComparison.OrdinalIgnoreCase) || target.StartsWith("net6.0", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsDotNet31Version(string target)
+        {
+            return target != null && target.StartsWith("netcoreapp3.1", StringComparison.OrdinalIgnoreCase);
         }
 
         // 01, 10, 11 in binares

--- a/Kudu.Core/Settings/ScmHostingConfigurations.cs
+++ b/Kudu.Core/Settings/ScmHostingConfigurations.cs
@@ -104,6 +104,12 @@ namespace Kudu.Core.Settings
             get { return int.TryParse(GetValue("TelemetryIntervalMinutes"), out int value) ? value : 30; }
         }
 
+        public static bool UseMSBuild167ForDotnet31
+        {
+            // this is disabled by default
+            get { return GetValue("UseMSBuild167ForDotnet31", "0") == "1"; }
+        }
+
         public static IPAddress ILBVip
         {
             get { return IPAddress.TryParse(GetValue(SettingsKeys.ILBVip), out var address) ? address : null; }


### PR DESCRIPTION
added `IsDotNet31Project()` and passing flag to `ResolveMSBuild16Dir(**bool IsDotNet31Project**)` to point to `MSBuilds/16.7.0` for dotnet 3.1